### PR TITLE
Adjust block gas limit

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -95,7 +95,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 2 seconds of compute with a 6 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = 2 * WEIGHT_PER_SECOND;
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
 
 parameter_types! {
     pub const BlockHashCount: BlockNumber = 2400;
@@ -618,7 +618,7 @@ impl pallet_nicks::Config for Runtime {
 /// Current approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM (on 4.4Ghz CPU).
 /// Given the 500ms Weight, from which 75% only are used for transactions,
-/// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 => 6_000_000.
+/// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 ~= 15_000_000.
 pub const GAS_PER_SECOND: u64 = 16_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
@@ -639,8 +639,15 @@ parameter_types! {
     pub const ChainId: u64 = 0x50;
 }
 
+pub struct FixedGasPrice;
+impl FeeCalculator for FixedGasPrice {
+	fn min_gas_price() -> U256 {
+		(1 * MILLIPLM / 1000_000).into()
+	}
+}
+
 impl pallet_evm::Config for Runtime {
-    type FeeCalculator = ();
+    type FeeCalculator = FixedGasPrice;
     type GasWeightMapping = GasWeightMapping;
     type CallOrigin = EnsureAddressRoot<Self::AccountId>;
     type WithdrawOrigin = EnsureAddressTruncated;
@@ -692,7 +699,8 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F> {
 }
 
 parameter_types! {
-    pub BlockGasLimit: U256 = U256::from(9_000_000);
+    pub BlockGasLimit: U256
+    = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
 }
 
 impl pallet_ethereum::Config for Runtime {


### PR DESCRIPTION
It's a tweak to accomodate evm smart contracts with big size (e.g. bridges, defi, etc). 